### PR TITLE
Make Docker image drastically smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-FROM node:9.9.0
+FROM nginx:stable-alpine
 
-WORKDIR /usr/src/app
-ENV NPM_CONFIG_LOGLEVEL warn
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY nginx/run.sh     /usr/share/nginx/run.sh
 
-RUN npm install -g serve
-EXPOSE 5000
+# You must build the management tool before creating the docker image, or the
+# image will not end up containing the management tool. Use the
+# `npm run dockerize` command to both build the tool and the docker image.
+COPY build            /usr/share/nginx/html
 
-COPY package.json package.json
-RUN npm install
-
-COPY . .
-
-CMD ["/usr/src/app/run"]
+CMD ["/usr/share/nginx/run.sh"]

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Running this project has 3 options:
     ```
     docker run -it -p 3000:5000 
     --name management-tool 
-    -e REACT_APP_ARROWHEAD_SR_URL=http://arrowhead.tmit.bme.hu:8342 
-    -e REACT_APP_ARROWHEAD_ORCH_URL=http://arrowhead.tmit.bme.hu:8340 
-    -e REACT_APP_ARROWHEAD_GK_URL=http://arrowhead.tmit.bme.hu:8348 
+    -e ARROWHEAD_SR_URL=http://arrowhead.tmit.bme.hu:8342 
+    -e ARROWHEAD_ORCH_URL=http://arrowhead.tmit.bme.hu:8340 
+    -e ARROWHEAD_GK_URL=http://arrowhead.tmit.bme.hu:8348 
     svetlint/management-tool
     ```
 
@@ -53,6 +53,7 @@ Running this project has 3 options:
 
 ## Available environment variables
    You can use the following environment variables in the `.env` file, or in the docker run command with the `-e` flag.
+   However, skip the `REACT_APP_` prefix of each variable if using docker.
    
     ```
     REACT_APP_ARROWHEAD_SR_URL=URL:port of your Service Registry Core System

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,43 @@
+user  nginx;
+worker_processes  auto;
+
+error_log   /var/log/nginx/error.log warn;
+pid         /var/run/nginx.pid;
+
+events {
+    worker_connections  128;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile  on;
+
+    keepalive_timeout  65;
+
+    gzip  on;
+
+    server {
+        listen       80;
+        server_name  localhost;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+
+        #error_page  404              /404.html;
+
+        error_page  500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+    }
+}

--- a/nginx/run.sh
+++ b/nginx/run.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Run script for NGINX Docker image.
+
+write_environs_with_prefix_as_js_to() {
+  PREFIX=$1
+  TARGET=$2
+  printf 'window.$ENV = {\n' > "${TARGET}"
+  for V in $(env); do
+    if [ "$V" != "${V#${PREFIX}}" ]; then
+      KV=$(printf '%s' "$V" | sed -e 's@=@: "@g')
+      printf '  %s",\n' "${KV}" >> "${TARGET}"
+    fi
+  done
+  printf '};\n' >> "${TARGET}"
+}
+
+write_environs_with_prefix_as_js_to "ARROWHEAD_" "/usr/share/nginx/html/env.js"
+
+# Start NGINX.
+nginx -g "daemon off;"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive",
     "start": "npm-run-all -p watch-css start-js",
     "start_prod": "node server.js",
-    "serve": "npm run build && npm run start_prod"
+    "serve": "npm run build && npm run start_prod",
+    "dockerize": "react-scripts build && docker build . -t management-tool"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",

--- a/public/env.js
+++ b/public/env.js
@@ -1,0 +1,1 @@
+window.$ENV = {};

--- a/public/index.html
+++ b/public/index.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
     <!--
-      manifest.json provides metadata used when your web app is added to the
+      asset-manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
+    <link rel="manifest" href="%PUBLIC_URL%/asset-manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
@@ -25,6 +25,7 @@
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>
+    <script src="%PUBLIC_URL%/env.js"></script>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/src/services/networkServiceAuth.js
+++ b/src/services/networkServiceAuth.js
@@ -1,7 +1,8 @@
 import axios from 'axios'
+import env from '../utils/env'
 
 const instance = axios.create({
-  baseURL: `${process.env.REACT_APP_ARROWHEAD_AUTH_URL}`,
+  baseURL: env.get("ARROWHEAD_AUTH_URL") || process.env.REACT_APP_ARROWHEAD_AUTH_URL,
   timeout: 10000
 })
 

--- a/src/services/networkServiceCH.js
+++ b/src/services/networkServiceCH.js
@@ -1,7 +1,8 @@
 import axios from 'axios'
+import env from '../utils/env'
 
 const instance = axios.create({
-  baseURL: `${process.env.REACT_APP_ARROWHEAD_CHOREOGRAPHER_URL}`,
+  baseURL: env.get("ARROWHEAD_CHOR_URL") || process.env.REACT_APP_ARROWHEAD_CHOR_URL,
   timeout: 10000
 })
 

--- a/src/services/networkServiceEH.js
+++ b/src/services/networkServiceEH.js
@@ -1,7 +1,8 @@
 import axios from 'axios'
+import env from '../utils/env'
 
 const instance = axios.create({
-  baseURL: `${process.env.REACT_APP_ARROWHEAD_EH_URL}`,
+  baseURL: env.get("ARROWHEAD_EH_URL") || process.env.REACT_APP_ARROWHEAD_EH_URL,
   timeout: 10000
 })
 

--- a/src/services/networkServiceGK.js
+++ b/src/services/networkServiceGK.js
@@ -1,7 +1,8 @@
 import axios from 'axios'
+import env from '../utils/env'
 
 const instance = axios.create({
-  baseURL: `${process.env.REACT_APP_ARROWHEAD_GK_URL}`,
+  baseURL: env.get("ARROWHEAD_GK_URL") || process.env.REACT_APP_ARROWHEAD_GK_URL,
   timeout: 10000
 })
 

--- a/src/services/networkServiceOrch.js
+++ b/src/services/networkServiceOrch.js
@@ -1,7 +1,8 @@
 import axios from 'axios'
+import env from '../utils/env'
 
 const instance = axios.create({
-  baseURL: `${process.env.REACT_APP_ARROWHEAD_ORCH_URL}`,
+  baseURL: env.get("ARROWHEAD_ORCH_URL") || process.env.REACT_APP_ARROWHEAD_ORCH_URL,
   timeout: 10000
 })
 

--- a/src/services/networkServiceSR.js
+++ b/src/services/networkServiceSR.js
@@ -1,7 +1,8 @@
 import axios from 'axios'
+import env from '../utils/env'
 
 const instance = axios.create({
-  baseURL: `${process.env.REACT_APP_ARROWHEAD_SR_URL}`,
+  baseURL: env.get("ARROWHEAD_SR_URL") || process.env.REACT_APP_ARROWHEAD_SR_URL,
   timeout: 10000
 })
 

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,0 +1,8 @@
+if (!window.$ENV) {
+  window.$ENV = {};
+}
+export default {
+  get: (name) => {
+    return window.$ENV[name];
+  }
+};


### PR DESCRIPTION
Another try at #2. This time I moved environment variables over to a static file called `/env.js`. The idea is that whoever wants to change these variables at runtime can overwrite the file. I've changed the Docker image such that it overwrites the file at startup with all environment variables it can find that start with "ARROWHEAD_". This removed the dependency on Perl, which also meant that I could use a smaller image.

I wanted the same `/env.js` file to be created by `react-scripts build` and populated with whatever `.env` file or enviornment variables it can find that starts with "REACT_APP_ARROWHEAD_", but I found no elegant way of doing this. Maybe you could look into it at some point. The problem is that react wont substitute `%REACT_APP_*%` or `process.env.REACT_APP_*` in `.js` files or within `<script></script>` tags. There is an open issue on the `create-react-app` repository (https://github.com/facebook/create-react-app/issues/8435). As a work-around, I simply added the `process.env` statements as fallbacks in the service files (e.g. `env.get("ARROWHEAD_AUTH_URL") || process.env.REACT_APP_ARROWHEAD_AUTH_URL`).
